### PR TITLE
Remove output channel length test from ecg2hb_amri test

### DIFF
--- a/test/pspm_ecg2hb_amri_test.m
+++ b/test/pspm_ecg2hb_amri_test.m
@@ -23,9 +23,6 @@ classdef pspm_ecg2hb_amri_test < pspm_testcase
             load(this.input_filename);
 
             this.verifyEqual(data{out_channel}.header.chantype, 'hb');
-
-            ecg_chan_indices = find(cell2mat(cellfun(@(x) strcmp(x.header.chantype, 'ecg'), data, 'uni', false)));
-            this.verifyEqual(numel(data{ecg_chan_indices(end)}.data), numel(data{out_channel}.data));
         end
     end
 


### PR DESCRIPTION


Changes proposed in this pull request:
- With 4d0cf4d pspm_ecg2hb_amri only returns heartbeat seconds and not a logic vector of the same length as the input. Hence, this test is removed.
