### PR TITLE
Update Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ permalink: /
 
 # Psychophysiological Modelling with PsPM: precision psychophysiology made easy
 
-**Current version: PsPM 6.1.2, released on 25.01.2024**
+**Current version: PsPM 7.0.0, released on 12.02.2025**
 
 <img class="PsPM_Web" src="assets/images/PsPM_Website_Figure_1.jpg" type="image/jpg" alt="PsPM" >
 

--- a/_posts/2024-01-02-learn.md
+++ b/_posts/2024-01-02-learn.md
@@ -7,68 +7,96 @@ permalink: /learn/
 The best place to start learning PsPM is the online course. We also run face-to-face courses, and you can drop in at our regular Q&A sessions. At the bottom of this page, you can find useful additional resources.
 
 # Online course
-## **Lecture 1: Theoretical overview (beginner)** 
 
-[![PsPM Lecture 1](https://www.caian.uni-bonn.de/media/pspm-lecture-1_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=a256bf0a-3c51-4bcf-bf6f-45b6f1013613)
 
-## **Lecture 2: Practical overview (beginner)** 
-We are sorry. There is currently no material available for Lecture 2.
+## **Lectures**
 
-## **Lecture 3: Theoretical overview (advanced)** 
 
-[![PsPM Lecture 3](https://www.caian.uni-bonn.de/media/pspm-lecture-3_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=99bbede5-f3a2-4993-8af0-0493f5dc11ab)
+### **Lecture 1: Theoretical Overview (Beginner)** 
 
-## **Lecture 4: Practical overview (advanced)** 
-We are sorry. There is currently no material available for Lecture 4.
+[![PsPM Lecture 1](https://www.caian.uni-bonn.de/media/preview_pspm_lecture_01.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=d0c8dcc3-685a-4b39-b7f7-0487f26c170e)
 
-## **Lecture 5: Skin Conductance Responses (SCR)** 
 
-[![PsPM Lecture 5](https://www.caian.uni-bonn.de/media/pspm-lecture-5_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=9710ce99-a74f-4073-aa8c-8edd400d1570)
+### **Lecture 2: Practical Overview (Beginner)** 
 
-## **Lecture 6: Pupil and gaze** (Dominik R. Bach)
+[![PsPM Lecture 2](https://www.caian.uni-bonn.de/media/preview_pspm_lecture_02.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=8392927d-772c-4320-a6d0-4463c0b4ca06)
 
-[![PsPM Lecture 6](https://www.caian.uni-bonn.de/media/pspm-lecture-6_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=bd2ed4fb-14ed-4e71-b32e-c3098912ac29)
 
-## **Lecture 7: Cardiac, respiratory and startle responses** 
-*Lecture 7a:* 
-[![PsPM Lecture 7a](https://www.caian.uni-bonn.de/media/pspm-lecture-7a_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=9bdf9373-fdb8-4b59-8a45-69263e715cc5)
+### **Lecture 3: Theoretical Overview (Advanced)** 
 
-*Lecture 7b:* 
-[![PsPM Lecture 7b](https://www.caian.uni-bonn.de/media/pspm-lecture-7b_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=a98b09d2-571f-4b9f-a6d9-f579f3bb8eec)     
+[![PsPM Lecture 3](https://www.caian.uni-bonn.de/media/preview_pspm_lecture_03.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=c7e55cc5-e990-46c6-ae5e-3e464318ede6)
 
-## **Lecture 8: Measuring fear conditioning with PsPM**
-We are sorry. There is currently no material available for Lecture 8.
 
-## **Tutorial 1: Data import and preprocessing**
-[![PsPM Tutorial 1](https://www.caian.uni-bonn.de/media/pspm-tutorial-1_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=99dbec06-b744-4461-8e70-131ce687a9b4)
+### **Lecture 4: Practical Overview (Advanced)** 
 
-## **Tutorial 2: GLM and timing definitions** 
-[![PsPM Tutorial 2](https://www.caian.uni-bonn.de/media/pspm-tutorial-2_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=e803118a-77c8-4f31-8744-c03b23bef6dc)
+[![PsPM Lecture 4](https://www.caian.uni-bonn.de/media/preview_pspm_lecture_04.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=93150a77-8f3d-4576-ac6d-8377039158f3)
 
-## **Tutorial 3: SCR and non-linear models** 
-[![PsPM Tutorial 3](https://www.caian.uni-bonn.de/media/pspm-tutorial-3_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=a310e31a-010b-4ebb-9076-daf15d3bf2f0)
 
-## **Tutorial 4: Pupil and gaze analysis** 
-[![PsPM Tutorial 4](https://www.caian.uni-bonn.de/media/pspm-tutorial-4_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=c15a44c7-7e04-4b7b-a0df-fa2e7b565739)   
+### **Lecture 5: Skin Conductance Responses (SCR) Analysis** 
 
-## **Tutorial 5: Cardiac, respiratory and SEBR analysis** 
-[![PsPM Tutorial 5](https://www.caian.uni-bonn.de/media/pspm-tutorial-5_small.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=a98b09d2-571f-4b9f-a6d9-f579f3bb8eec)
+[![PsPM Lecture 5](https://www.caian.uni-bonn.de/media/preview_pspm_lecture_05.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=c9704c8a-0959-4aad-a0d7-92821bfbe1fa)
 
-## **Tutorial 6: Workflow automation** 
-* [Slides tutorial 6a](https://docs.google.com/presentation/d/1LsaEB3MozxvxJVSfZUQdXBhJ6BjEkqLeFf_0nZiD4Zc/edit?usp=sharing)
-* [Files tutorial 6a](https://drive.google.com/open?id=1na1wGlCaDZLreLtEi1iEj1Y5Glqd4mFP)  
-* [Slides tutorial 6b](https://docs.google.com/presentation/d/1YuNKejeTsCrpURCYGjCTf0_m62dsVh9Z9xu05JRnpfw/edit?usp=sharing)
-* [Files tutorial 6b](https://drive.google.com/open?id=1g5Wnmu1ghUtNWo9vMWv52WTL4qNi8N88)  
 
-# Course preparation
+### **Lecture 6: Pupil & Gaze Data Analysis** 
+
+[![PsPM Lecture 6](https://www.caian.uni-bonn.de/media/preview_pspm_tutorial_06.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=44b77fb2-a7e3-48e8-b3da-6c9827e04ce9)
+
+
+### **Lecture 7: Cardiac, Respiratory and EMG Models** 
+
+[![PsPM Lecture 7](https://www.caian.uni-bonn.de/media/preview_pspm_lecture_07.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=c11981af-9c8b-451c-ae27-e2f4656fc48a)
+
+
+### **Lecture 8: Measuring Fear Conditioning with PsPM**
+
+[![PsPM Lecture 8](https://www.caian.uni-bonn.de/media/preview_pspm_lecture_08.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=4c431ac3-a169-4dd3-a00b-d961bf0e3da5)
+
+
+## **Tutorials**
+
+### **Tutorial 1: Import & Preparation**
+
+[![PsPM Tutorial 1](https://www.caian.uni-bonn.de/media/preview_pspm_tutorial_01.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=d5384f68-edca-467a-8935-d0c85355c672)
+
+
+### **Tutorial 2: GLM & Timing** 
+
+[![PsPM Tutorial 2](https://www.caian.uni-bonn.de/media/preview_pspm_tutorial_02.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=daaeca83-a48e-4f58-b077-c850fbc3429b)
+
+
+### **Tutorial 3: SCR & Non-Linear Model** 
+
+[![PsPM Tutorial 3](https://www.caian.uni-bonn.de/media/preview_pspm_tutorial_03.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=67ac1e61-84f1-4c16-8798-521a6e9f5730)
+
+
+### **Tutorial 4: Pupil & Gaze** 
+
+[![PsPM Tutorial 4](https://www.caian.uni-bonn.de/media/preview_pspm_tutorial_04.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=64b02438-9937-4cb3-87a9-5b012c8d9370)   
+
+
+### **Tutorial 5: Heart, Respiration, EMG** 
+[![PsPM Tutorial 5](https://www.caian.uni-bonn.de/media/preview_pspm_tutorial_05.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=cd7260f8-79fc-455b-8cd9-3c152029b19a)
+
+
+### **Tutorial 6: Workflow Automation** 
+
+[![PsPM Tutorial 6](https://www.caian.uni-bonn.de/media/preview_pspm_tutorial_06.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=7c24a0b6-d340-4d01-90d2-861bbcb9dc19)
+
+
+
+
+# Course Preparation
 Before getting started with our lectures and tutorials, we suggest you install Matlab/PsPM and the example data sets, in order to replicate the demonstrations. 
 
 * [Download latest PsPM version](https://bachlab.github.io/PsPM/download/)
 * [Download GLM dataset](https://github.com/bachlab/PsPM-tutorial-datasets/releases/download/tutorial-datasets/Tutorial_dataset_GLM.zip)
 * [Download non-linear model dataset](https://github.com/bachlab/PsPM-tutorial-datasets/releases/download/tutorial-datasets/Tutorial_dataset_DCM.zip)
-* [PsPM overview paper](https://doi.org/10.1111/psyp).13209) ([open version](https://discovery.ucl.ac.uk/id/eprint/10070115/))
+* [PsPM overview paper](https://doi/10.1111/psyp.13209) ([open version](https://discovery.ucl.ac.uk/id/eprint/10070115/))
 
-# Getting help
+
+
+
+# Getting Help
 
 * [Function reference](https://bachlab.github.io/PsPM/reference/)
 * [Discussion forum on github](https://github.com/bachlab/PsPM/discussions).

--- a/_posts/2024-01-05-news.md
+++ b/_posts/2024-01-05-news.md
@@ -4,6 +4,13 @@ title: News
 permalink: /news/
 ---
 
+### 12.02.2025
+
+PsPM 7.0.0 released, a complete revamp of the GUI and function logic with a focus on user experience, robustness and maintainability. Backwards compatibility is partial: PsPM data files from previous versions can be read, PsPM first-level model files are can be processed with the exception of extracting segments, Matlabbatch and function calls created with previous PsPM versions require adaptation.
+
+[![PsPM V7.0.0](https://www.caian.uni-bonn.de/media/pspm-v7-0-0.jpg)](https://electure.uni-bonn.de/paella7/ui/watch.html?id=fafa79ae-3777-4496-bbfa-0daf3fa47414)
+
+
 ### 29.02.2024 
 
 Fear conditioning can be index by [various psychophysiological data types](https://doi.org/10.1016/j.neubiorev.2020.04.019), but how these indices relate to each other? In this new paper, [Mancinelli, Sporrer, et al.](https://doi.org/10.3758/s13428-024-02341-3) find in N = 256 persons that fear conditioning strength estimated from SCR, heart period, respiration, and pupil size, covaries on only one dimension, suggesting that these indices are measuring the same latent variable. Combining two or more of these indices improves [retrodictive validity](https://doi.org/10.1038/s41562-020-00976-8) in out-of-sample generalisation tests and can thus help reducing sample size at the same statistical power.


### PR DESCRIPTION
Updates to the page:
- replaced all video and image links,
- added one line of space after each section,
- added two subtitles (lectures, tutorials) and capitalized titles for better readability,
- optimized for SEO/changed lecture headings from title font size 2 to 3,
- deleted old notifications where videos were missing but will be available again from now on
- deleted links to outdated course material for tutorial six slides

Fixes # .

Changes proposed in this pull request:
- 
- 
- 
