### PR TITLE
epochs edgecase fix in pspm_logical2epochs and more test

### DIFF
--- a/src/pspm_logical2epochs.m
+++ b/src/pspm_logical2epochs.m
@@ -5,7 +5,7 @@ function epochs = pspm_logical2epochs(index, sr)
 % ● Format
 %   epochs = logical2pspm_epochs(index, sr)
 % ● Arguments
-%   *        index : [logical] index vector of length datalength
+%   *        index : [logical] index vector
 %   *           sr : sample rate used when index was created
 %                    
 % ● Outputs
@@ -14,6 +14,9 @@ function epochs = pspm_logical2epochs(index, sr)
 %   Written in 2024 by Bernhard Agoué von Raußendorf
 
 %%    
+
+N   = numel(index);
+
 % Compute the differences between consecutive elements in the index array,
 % with padding at the start and end
 diff_index = diff([0; index(:); 0]);
@@ -23,6 +26,8 @@ onsets = find(diff_index == 1);
 
 % Offsets are where the difference is -1 (1 to 0 transition)
 offsets = find(diff_index == -1);
+
+if ~isempty(offsets); offsets(end) = min(offsets(end) , N); end
 
 % Combine onsets and offsets into an nx2 matrix
 epochs = double([onsets, offsets]);

--- a/src/pspm_logical2epochs.m
+++ b/src/pspm_logical2epochs.m
@@ -15,8 +15,6 @@ function epochs = pspm_logical2epochs(index, sr)
 
 %%    
 
-N   = numel(index);
-
 % Compute the differences between consecutive elements in the index array,
 % with padding at the start and end
 diff_index = diff([0; index(:); 0]);
@@ -27,13 +25,17 @@ onsets = find(diff_index == 1);
 % Offsets are where the difference is -1 (1 to 0 transition)
 offsets = find(diff_index == -1);
 
-if ~isempty(offsets); offsets(end) = min(offsets(end) , N); end
 
 % Combine onsets and offsets into an nx2 matrix
 epochs = double([onsets, offsets]);
 
 % If the sample rate (sr) is not 1, convert indices back to time
-if nargin > 1 && sr ~= 1
+if nargin > 1 &&  sr >= 1 % sr ~= 1
     epochs = (epochs - 1) / sr;
+else
+    N   = numel(index);
+    if ~isempty(offsets); offsets(end) = min(offsets(end) , N); end
+    epochs = double([onsets, offsets]);
 end
+
 end

--- a/test/pspm_logical2epochs_test.m
+++ b/test/pspm_logical2epochs_test.m
@@ -29,14 +29,47 @@ classdef pspm_logical2epochs_test < matlab.unittest.TestCase
             testCase.verifyEqual(actualOutput, expectedOutput);
         end
        
+        function testWithEdgeCase(testCase)
+            index = double([0; 1; 1; 0; 0; 1; 0; 0; 0; 1]);
+            sr = 1;
+            expectedOutput = [2, 4; 6, 7; 10 , 10]; % last offset not exclusive
+            actualOutput = pspm_logical2epochs(index, sr);
+            testCase.verifyEqual(actualOutput, expectedOutput);        
+        end   
 
         function testWithSampleRateConversion(testCase)
-            index = double([0; 0; 1; 0; 1; 0; 0; 0; 0; 0]);
+            index = double([0; 0; 1; 0; 1; 0; 0; 0; 0; ]);
             sr = 2;
             expectedOutput = [1, 1.5; 2, 2.5];
             actualOutput = pspm_logical2epochs(index, sr);
             testCase.verifyEqual(actualOutput, expectedOutput);
         end
+
+        function testWithSampleRateConversionWithEdgeCase(testCase)
+            index = double([0; 0; 1; 0; 1; 0; 0; 0; 0; 1]);
+            sr = 2;
+            expectedOutput = [1, 1.5; 2, 2.5; 4.5, 4.5]; % last offset not exclusive
+            actualOutput = pspm_logical2epochs(index, sr);
+            testCase.verifyEqual(actualOutput, expectedOutput);
+        end
+
+        function testWithEmptyVector(testCase)
+            index = [];
+            sr = 1;
+            expectedOutput = []; 
+            actualOutput = pspm_logical2epochs(index, sr);
+            testCase.verifyEqual(actualOutput, expectedOutput);        
+        end   
+
+        function testWithEmptyVectorWithSampleRateConversion(testCase)
+            index = [];
+            sr = 2;
+            expectedOutput = []; 
+            actualOutput = pspm_logical2epochs(index, sr);
+            testCase.verifyEqual(actualOutput, expectedOutput);        
+        end  
+
+
 
     end
 end

--- a/test/pspm_logical2epochs_test.m
+++ b/test/pspm_logical2epochs_test.m
@@ -23,17 +23,15 @@ classdef pspm_logical2epochs_test < matlab.unittest.TestCase
     methods (Test)
         function testBasicFunctionality(testCase)
             index = double([0; 1; 1; 0; 0; 1; 0; 0; 0; 0]);
-            sr = 1;
             expectedOutput = [2, 4; 6, 7];
-            actualOutput = pspm_logical2epochs(index, sr);
+            actualOutput = pspm_logical2epochs(index);
             testCase.verifyEqual(actualOutput, expectedOutput);
         end
-       
+
         function testWithEdgeCase(testCase)
             index = double([0; 1; 1; 0; 0; 1; 0; 0; 0; 1]);
-            sr = 1;
             expectedOutput = [2, 4; 6, 7; 10 , 10]; % last offset not exclusive
-            actualOutput = pspm_logical2epochs(index, sr);
+            actualOutput = pspm_logical2epochs(index);
             testCase.verifyEqual(actualOutput, expectedOutput);        
         end   
 
@@ -48,10 +46,18 @@ classdef pspm_logical2epochs_test < matlab.unittest.TestCase
         function testWithSampleRateConversionWithEdgeCase(testCase)
             index = double([0; 0; 1; 0; 1; 0; 0; 0; 0; 1]);
             sr = 2;
-            expectedOutput = [1, 1.5; 2, 2.5; 4.5, 4.5]; % last offset not exclusive
+            expectedOutput = [1, 1.5; 2, 2.5; 4.5, 5]; % last offset not exclusive
             actualOutput = pspm_logical2epochs(index, sr);
             testCase.verifyEqual(actualOutput, expectedOutput);
         end
+
+        function testWithSampleRateOneWithEdgeCase(testCase)
+            index = double([0; 0; 1; 0; 1; 0; 0; 0; 0; 1]);
+            sr = 1;
+            expectedOutput = [2, 3; 4, 5; 9, 10];
+            actualOutput = pspm_logical2epochs(index, sr);
+            testCase.verifyEqual(actualOutput, expectedOutput);
+        end        
 
         function testWithEmptyVector(testCase)
             index = [];

--- a/test/pspm_testdata_gen.m
+++ b/test/pspm_testdata_gen.m
@@ -39,14 +39,14 @@ function outfile = pspm_testdata_gen(channels, duration, filename)
 %                             in continuous channels
 %                           -> 'min' and 'max' could be used as a
 %                           counterpart for a continuous wave form channel
-% filename: filname of the .mat file, where the generated data will be
+% filename: filename of the .mat file, where the generated data will be
 %           saved (optional).
 %
 % outfile:  a struct with the two following fields:
 %           - .infos: a struct with the fields '.duration' and '.durationinfo'
 %           - .data:  a cell array of struct with the following fields for
 %                    each channel:
-%                    - .data:   the genarated data as a column vector
+%                    - .data:   the generated data as a column vector
 %                    - .header: a struct with the fields '.chantype',
 %                               '.units', '.sr' and '.eventrt' for eventbased
 %                               channels or '.freq' and  for continuous channels


### PR DESCRIPTION
Fixes an edge case in conversion from logical index to epochs.

Changes proposed in this pull request:
- the epoch indices should not have a larger index than the number of data points.
- 
- 
