### PR TITLE
generalise pspm_pull_zenodo to work with all PsPM data sets

### DIFF
--- a/src/pspm_pull_zenodo.m
+++ b/src/pspm_pull_zenodo.m
@@ -47,13 +47,14 @@ for iFiles = 1:2
 
         if any(newpathindx)
             newpath = fullfile(datapath, newdir(newpathindx).name);
-            filelist = dir(fullfile(newpath, '*.*'));
+            filelist = dir(newpath);
+            filelist = filelist(~[filelist.isdir]);   % remove directories
             oldfile = fullfile(newpath, {filelist.name});
             newfile = fullfile(datapath, {filelist.name});
             for i_fn = 1:numel(oldfile)
                 movefile(oldfile{i_fn}, newfile{i_fn});
             end
-            rmdir(newpath);
+            rmdir(newpath, 's');
         end
     end
 end

--- a/src/pspm_pull_zenodo.m
+++ b/src/pspm_pull_zenodo.m
@@ -47,7 +47,7 @@ for iFiles = 1:2
 
         if any(newpathindx)
             newpath = fullfile(datapath, newdir(newpathindx).name);
-            filelist = dir(fullfile(newpath, '*.mat'));
+            filelist = dir(fullfile(newpath, '*.*'));
             oldfile = fullfile(newpath, {filelist.name});
             newfile = fullfile(datapath, {filelist.name});
             for i_fn = 1:numel(oldfile)


### PR DESCRIPTION
Changes proposed in this pull request:
- `pspm_pull_zenodo` expects only *.mat files, but some zenodo data sets (e.g. SPRM) also contain meta data as *.txt
- generalise the function to handle these files
