### PR TITLE
assign outputs to varargout [#898]

### DIFF
--- a/src/pspm_data_editor.m
+++ b/src/pspm_data_editor.m
@@ -370,6 +370,14 @@ function varargout = pspm_data_editor_OutputFcn(hObject, ~, handles)
 %   handles    structure with handles and user data (see GUIDATA)
 % UIWAIT makes pspm_data_editor wait for user response (see UIRESUME)
 % handles.lbEpochsvarargout{1} = handles.output;
+for i = 1:nargout
+    varargout{i} = []; %#ok<AGROW>
+end
+
+if isfield(handles, 'output')
+    varargout{1} = handles.output;
+end
+
 delete(hObject);
 
 function lbEpochs_Callback(hObject, ~, ~)


### PR DESCRIPTION
Fixes #898.

This PR resolves errors occurring when closing `pspm_data_editor`, specifically:
```matlab
Error: One or more output arguments not assigned during call to "varargout".
```

- OutputFcn now assigns outputs based on nargout
- Prevents errors when callers request more outputs than expected
- Avoids fragile hard-coded assignments